### PR TITLE
Implement cylindrical scatter and gather

### DIFF
--- a/include/spark/interpolate/field.h
+++ b/include/spark/interpolate/field.h
@@ -13,7 +13,8 @@ void field_at_particles(const spatial::TUniformGrid<T, NX>& field,
 template <typename T, unsigned NX, unsigned NV>
 void field_at_particles_cylindrical(const spatial::TUniformGrid<T, NX>& field,
                         const particle::ChargedSpecies<NX, NV>& species,
-                        core::TMatrix<T, 1>& out);
+                        core::TMatrix<T, 1>& out, 
+                        const double r0);
 
 template <typename T, unsigned NX>
 T field_at_position(const spatial::TUniformGrid<T, NX>& field, const core::Vec<NX>& pos);

--- a/include/spark/interpolate/field.h
+++ b/include/spark/interpolate/field.h
@@ -10,6 +10,11 @@ void field_at_particles(const spatial::TUniformGrid<T, NX>& field,
                         const particle::ChargedSpecies<NX, NV>& species,
                         core::TMatrix<T, 1>& out);
 
+template <typename T, unsigned NX, unsigned NV>
+void field_at_particles_cylindrical(const spatial::TUniformGrid<T, NX>& field,
+                        const particle::ChargedSpecies<NX, NV>& species,
+                        core::TMatrix<T, 1>& out);
+
 template <typename T, unsigned NX>
 T field_at_position(const spatial::TUniformGrid<T, NX>& field, const core::Vec<NX>& pos);
 }  // namespace spark::interpolate

--- a/include/spark/interpolate/weight.h
+++ b/include/spark/interpolate/weight.h
@@ -8,6 +8,6 @@ template <class GridType, unsigned NX, unsigned NV>
 void weight_to_grid(const spark::particle::ChargedSpecies<NX, NV>& species, GridType& out);
 
 template <class GridType, unsigned NX, unsigned NV>
-void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<NX, NV>& species, GridType& out);
+void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<NX, NV>& species, GridType& out, const double r0);
 
 }

--- a/include/spark/interpolate/weight.h
+++ b/include/spark/interpolate/weight.h
@@ -7,4 +7,7 @@ namespace spark::interpolate {
 template <class GridType, unsigned NX, unsigned NV>
 void weight_to_grid(const spark::particle::ChargedSpecies<NX, NV>& species, GridType& out);
 
+template <class GridType, unsigned NX, unsigned NV>
+void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<NX, NV>& species, GridType& out);
+
 }

--- a/src/interpolate/field.cpp
+++ b/src/interpolate/field.cpp
@@ -60,6 +60,40 @@ void field_at_particles(const spatial::TUniformGrid<T, 2>& field,
     }
 }
 
+template <typename T, unsigned NV>
+void field_at_particles_cylindrical(const spatial::TUniformGrid<T, 2>& field,
+                        const particle::ChargedSpecies<2, NV>& species,
+                        TMatrix<T, 1>& out) {
+    const size_t n = species.n();
+    out.resize({n});
+
+    auto* x = species.x();
+
+    const auto dx = field.dx();
+    const auto& f = field.data();
+    const auto mdx = 1.0 / dx;
+
+    for (size_t i = 0; i < n; ++i) {
+        const auto xp = x[i] * mdx;
+        const auto xmesh_lower_left = xp.template apply<std::floor>();
+        const auto xmesh_upper_right = xmesh_lower_left + 1.0;
+        const auto idx = xmesh_lower_left.template to<size_t>();
+
+        double rj = xmesh_lower_left.y * dx.y;
+
+        double f1 = (rj + 0.5 * (xp.y - xmesh_lower_left.y) * dx.y) / (rj + 0.5 * dx.y);
+        double f2 = (rj + 0.5 * (xp.y - xmesh_lower_left.y + 1) * dx.y) / (rj + 0.5 * dx.y);
+
+        const double a1 = (xmesh_upper_right.x - xp.x) * (xmesh_upper_right.y - xp.y) * f2;
+        const double a2 = (xp.x - xmesh_lower_left.x) * (xmesh_upper_right.y - xp.y) * f2;
+        const double a3 = (xp.x - xmesh_lower_left.x) * (xp.y - xmesh_lower_left.y) * f1;
+        const double a4 = (xmesh_upper_right.x - xp.x) * (xp.y - xmesh_lower_left.y) * f1;
+
+        out[i] = a1 * f(idx.x, idx.y) + a2 * f(idx.x + 1, idx.y) + a3 * f(idx.x + 1, idx.y + 1) +
+                 a4 * f(idx.x, idx.y + 1);
+    }
+}
+
 }  // namespace
 
 template <typename T, unsigned NX, unsigned NV>
@@ -67,6 +101,13 @@ void spark::interpolate::field_at_particles(const spark::spatial::TUniformGrid<T
                                             const spark::particle::ChargedSpecies<NX, NV>& species,
                                             core::TMatrix<T, 1>& out) {
     ::field_at_particles(field, species, out);
+}
+template <typename T, unsigned NX, unsigned NV>
+void spark::interpolate::field_at_particles_cylindrical(
+    const spark::spatial::TUniformGrid<T, NX>& field,
+    const spark::particle::ChargedSpecies<NX, NV>& species,
+    core::TMatrix<T, 1>& out) {
+    ::field_at_particles_cylindrical(field, species, out);
 }
 template <typename T, unsigned NX>
 T interpolate::field_at_position(const spatial::TUniformGrid<T, NX>& field, const Vec<NX>& pos) {
@@ -101,6 +142,11 @@ template void interpolate::field_at_particles(const spatial::TUniformGrid<Vec<1>
 template void interpolate::field_at_particles(const spatial::TUniformGrid<Vec<2>, 2>& field,
                                               const particle::ChargedSpecies<2, 3>& species,
                                               TMatrix<Vec<2>, 1>& out);
+
+template void interpolate::field_at_particles_cylindrical(
+    const spatial::TUniformGrid<Vec<2>, 2>& field,
+    const particle::ChargedSpecies<2, 3>& species,
+    TMatrix<Vec<2>, 1>& out);
 
 template double interpolate::field_at_position(const spatial::UniformGrid<2>& field,
                                                const core::Vec<2>& pos);

--- a/src/interpolate/field.cpp
+++ b/src/interpolate/field.cpp
@@ -63,7 +63,8 @@ void field_at_particles(const spatial::TUniformGrid<T, 2>& field,
 template <typename T, unsigned NV>
 void field_at_particles_cylindrical(const spatial::TUniformGrid<T, 2>& field,
                         const particle::ChargedSpecies<2, NV>& species,
-                        TMatrix<T, 1>& out) {
+                        TMatrix<T, 1>& out, 
+                        const double r0) {
     const size_t n = species.n();
     out.resize({n});
 
@@ -79,7 +80,7 @@ void field_at_particles_cylindrical(const spatial::TUniformGrid<T, 2>& field,
         const auto xmesh_upper_right = xmesh_lower_left + 1.0;
         const auto idx = xmesh_lower_left.template to<size_t>();
 
-        double rj = xmesh_lower_left.y * dx.y;
+        double rj = r0 + xmesh_lower_left.y * dx.y;
 
         double f1 = (rj + 0.5 * (xp.y - xmesh_lower_left.y) * dx.y) / (rj + 0.5 * dx.y);
         double f2 = (rj + 0.5 * (xp.y - xmesh_lower_left.y + 1) * dx.y) / (rj + 0.5 * dx.y);
@@ -103,11 +104,11 @@ void spark::interpolate::field_at_particles(const spark::spatial::TUniformGrid<T
     ::field_at_particles(field, species, out);
 }
 template <typename T, unsigned NX, unsigned NV>
-void spark::interpolate::field_at_particles_cylindrical(
-    const spark::spatial::TUniformGrid<T, NX>& field,
-    const spark::particle::ChargedSpecies<NX, NV>& species,
-    core::TMatrix<T, 1>& out) {
-    ::field_at_particles_cylindrical(field, species, out);
+void spark::interpolate::field_at_particles_cylindrical(const spark::spatial::TUniformGrid<T, NX>& field,
+                                                        const spark::particle::ChargedSpecies<NX, NV>& species,
+                                                        core::TMatrix<T, 1>& out, 
+                                                        const double r0) {
+    ::field_at_particles_cylindrical(field, species, out, r0);
 }
 template <typename T, unsigned NX>
 T interpolate::field_at_position(const spatial::TUniformGrid<T, NX>& field, const Vec<NX>& pos) {
@@ -143,10 +144,10 @@ template void interpolate::field_at_particles(const spatial::TUniformGrid<Vec<2>
                                               const particle::ChargedSpecies<2, 3>& species,
                                               TMatrix<Vec<2>, 1>& out);
 
-template void interpolate::field_at_particles_cylindrical(
-    const spatial::TUniformGrid<Vec<2>, 2>& field,
-    const particle::ChargedSpecies<2, 3>& species,
-    TMatrix<Vec<2>, 1>& out);
+template void interpolate::field_at_particles_cylindrical(const spatial::TUniformGrid<Vec<2>, 2>& field,
+                                                          const particle::ChargedSpecies<2, 3>& species,
+                                                          TMatrix<Vec<2>, 1>& out, 
+                                                          const double r0);
 
 template double interpolate::field_at_position(const spatial::UniformGrid<2>& field,
                                                const core::Vec<2>& pos);

--- a/src/interpolate/weight.cpp
+++ b/src/interpolate/weight.cpp
@@ -103,38 +103,38 @@ void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<2, NV>& sp
     cache_grid.fill({0, 0, 0, 0});
     out.set(0.0);
 
-    const auto [mdx, mdy] = 1.0 / out.dx();
-    const auto [nx, ny] = out.n();
+    const auto [mdz, mdr] = 1.0 / out.dx();
+    const auto [nz, nr] = out.n();
 
     auto& grid_data = out.data();
 
     for (size_t i = 0; i < n; ++i) {
-        const double xp = x[i].x * mdx;
-        const double yp = x[i].y * mdy;
+        const double zp = x[i].x * mdz;
+        const double rp = x[i].y * mdr;
 
-        const auto jf = floor(xp);
-        const auto kf = floor(yp);
+        const auto jf = floor(zp);
+        const auto kf = floor(rp);
 
         const auto j = static_cast<size_t>(jf);
         const auto k = static_cast<size_t>(kf);
 
-        const double x_local = xp - jf;
-        const double y_local = yp - kf;
+        const double z_local = zp - jf;
+        const double r_local = rp - kf;
 
         double rj = k * out.dx().y;
 
-        double f1 = (rj + 0.5 * y_local * out.dx().y) / (rj + 0.5 * out.dx().y);
-        double f2 = (rj + 0.5 * (y_local + 1.0) * out.dx().y) / (rj + 0.5 * out.dx().y);
+        double f1 = (rj + 0.5 * r_local * out.dx().y) / (rj + 0.5 * out.dx().y);
+        double f2 = (rj + 0.5 * (r_local + 1.0) * out.dx().y) / (rj + 0.5 * out.dx().y);
 
         auto& c = cache_grid(j, k);
-        c[0] += (1.0 - x_local) * (1.0 - y_local) * f2;
-        c[1] += x_local * (1.0 - y_local) * f2;
-        c[2] += (1.0 - x_local) * y_local * f1;
-        c[3] += x_local * y_local * f1;
+        c[0] += (1.0 - z_local) * (1.0 - r_local) * f2;
+        c[1] += z_local * (1.0 - r_local) * f2;
+        c[2] += (1.0 - z_local) * r_local * f1;
+        c[3] += z_local * r_local * f1;
     }
 
-    for (int j = 0; j < nx - 1; j++) {
-        for (int k = 0; k < ny - 1; k++) {
+    for (int j = 0; j < nz - 1; j++) {
+        for (int k = 0; k < nr - 1; k++) {
             auto& c = cache_grid(j, k);
 
             grid_data(j, k) += c[0];
@@ -144,14 +144,14 @@ void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<2, NV>& sp
         }
     }
 
-    for (size_t j = 0; j < nx; j++) {
+    for (size_t j = 0; j < nz; j++) {
         grid_data(j, 0) *= 2.0;
-        grid_data(j, ny - 1) *= 2.0;
+        grid_data(j, nr - 1) *= 2.0;
     }
 
-    for (size_t k = 0; k < ny; k++) {
+    for (size_t k = 0; k < nr; k++) {
         grid_data(0, k) *= 2.0;
-        grid_data(nx - 1, k) *= 2.0;
+        grid_data(nz - 1, k) *= 2.0;
     }
 }
 

--- a/src/interpolate/weight.cpp
+++ b/src/interpolate/weight.cpp
@@ -94,7 +94,8 @@ void weight_to_grid(const spark::particle::ChargedSpecies<2, NV>& species,
 
 template <unsigned NV>
 void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<2, NV>& species,
-                    spark::spatial::UniformGrid<2>& out) {
+                    spark::spatial::UniformGrid<2>& out,
+                    const double r0) {
     const auto n = species.n();
     auto* x = species.x();
 
@@ -121,7 +122,7 @@ void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<2, NV>& sp
         const double z_local = zp - jf;
         const double r_local = rp - kf;
 
-        double rj = k * out.dx().y;
+        double rj = r0 + k * out.dx().y;
 
         double f1 = (rj + 0.5 * r_local * out.dx().y) / (rj + 0.5 * out.dx().y);
         double f2 = (rj + 0.5 * (r_local + 1.0) * out.dx().y) / (rj + 0.5 * out.dx().y);
@@ -186,3 +187,4 @@ template void spark::interpolate::weight_to_grid_cylindrical(
 template void spark::interpolate::weight_to_grid_cylindrical(
     const spark::particle::ChargedSpecies<2, 3>& species,
     spark::spatial::UniformGrid<2>& out);
+    

--- a/src/interpolate/weight.cpp
+++ b/src/interpolate/weight.cpp
@@ -165,8 +165,9 @@ void spark::interpolate::weight_to_grid(const spark::particle::ChargedSpecies<NX
 template <class GridType, unsigned NX, unsigned NV>
 void spark::interpolate::weight_to_grid_cylindrical(
     const spark::particle::ChargedSpecies<NX, NV>& species,
-    GridType& out) {
-    ::weight_to_grid_cylindrical(species, out);
+    GridType& out,
+    const double r0) {
+    ::weight_to_grid_cylindrical(species, out, r0);
 }
 
 template void spark::interpolate::weight_to_grid(
@@ -183,8 +184,9 @@ template void spark::interpolate::weight_to_grid(
     spark::spatial::UniformGrid<2>& out);
 template void spark::interpolate::weight_to_grid_cylindrical(
     const spark::particle::ChargedSpecies<2, 1>& species,
-    spark::spatial::UniformGrid<2>& out);
+    spark::spatial::UniformGrid<2>& out,
+    const double r0);
 template void spark::interpolate::weight_to_grid_cylindrical(
     const spark::particle::ChargedSpecies<2, 3>& species,
-    spark::spatial::UniformGrid<2>& out);
-    
+    spark::spatial::UniformGrid<2>& out,
+    const double r0);

--- a/src/interpolate/weight.cpp
+++ b/src/interpolate/weight.cpp
@@ -92,10 +92,80 @@ void weight_to_grid(const spark::particle::ChargedSpecies<2, NV>& species,
 }
 }  // namespace
 
+template <unsigned NV>
+void weight_to_grid_cylindrical(const spark::particle::ChargedSpecies<2, NV>& species,
+                    spark::spatial::UniformGrid<2>& out) {
+    const auto n = species.n();
+    auto* x = species.x();
+
+    static auto cache_grid = spark::core::TMatrix<std::array<double, 4>, 2>();
+    cache_grid.resize(out.n());
+    cache_grid.fill({0, 0, 0, 0});
+    out.set(0.0);
+
+    const auto [mdx, mdy] = 1.0 / out.dx();
+    const auto [nx, ny] = out.n();
+
+    auto& grid_data = out.data();
+
+    for (size_t i = 0; i < n; ++i) {
+        const double xp = x[i].x * mdx;
+        const double yp = x[i].y * mdy;
+
+        const auto jf = floor(xp);
+        const auto kf = floor(yp);
+
+        const auto j = static_cast<size_t>(jf);
+        const auto k = static_cast<size_t>(kf);
+
+        const double x_local = xp - jf;
+        const double y_local = yp - kf;
+
+        double rj = k * out.dx().y;
+
+        double f1 = (rj + 0.5 * y_local * out.dx().y) / (rj + 0.5 * out.dx().y);
+        double f2 = (rj + 0.5 * (y_local + 1.0) * out.dx().y) / (rj + 0.5 * out.dx().y);
+
+        auto& c = cache_grid(j, k);
+        c[0] += (1.0 - x_local) * (1.0 - y_local) * f2;
+        c[1] += x_local * (1.0 - y_local) * f2;
+        c[2] += (1.0 - x_local) * y_local * f1;
+        c[3] += x_local * y_local * f1;
+    }
+
+    for (int j = 0; j < nx - 1; j++) {
+        for (int k = 0; k < ny - 1; k++) {
+            auto& c = cache_grid(j, k);
+
+            grid_data(j, k) += c[0];
+            grid_data(j + 1, k) += c[1];
+            grid_data(j, k + 1) += c[2];
+            grid_data(j + 1, k + 1) += c[3];
+        }
+    }
+
+    for (size_t j = 0; j < nx; j++) {
+        grid_data(j, 0) *= 2.0;
+        grid_data(j, ny - 1) *= 2.0;
+    }
+
+    for (size_t k = 0; k < ny; k++) {
+        grid_data(0, k) *= 2.0;
+        grid_data(nx - 1, k) *= 2.0;
+    }
+}
+
 template <class GridType, unsigned NX, unsigned NV>
 void spark::interpolate::weight_to_grid(const spark::particle::ChargedSpecies<NX, NV>& species,
                                         GridType& out) {
     ::weight_to_grid(species, out);
+}
+
+template <class GridType, unsigned NX, unsigned NV>
+void spark::interpolate::weight_to_grid_cylindrical(
+    const spark::particle::ChargedSpecies<NX, NV>& species,
+    GridType& out) {
+    ::weight_to_grid_cylindrical(species, out);
 }
 
 template void spark::interpolate::weight_to_grid(
@@ -108,5 +178,11 @@ template void spark::interpolate::weight_to_grid(
     const spark::particle::ChargedSpecies<2, 1>& species,
     spark::spatial::UniformGrid<2>& out);
 template void spark::interpolate::weight_to_grid(
+    const spark::particle::ChargedSpecies<2, 3>& species,
+    spark::spatial::UniformGrid<2>& out);
+template void spark::interpolate::weight_to_grid_cylindrical(
+    const spark::particle::ChargedSpecies<2, 1>& species,
+    spark::spatial::UniformGrid<2>& out);
+template void spark::interpolate::weight_to_grid_cylindrical(
     const spark::particle::ChargedSpecies<2, 3>& species,
     spark::spatial::UniformGrid<2>& out);


### PR DESCRIPTION
## Description

This PR implements cylindrical scatter and gather algorithms for plasma particle simulations in cylindrical coordinates.

## Reference

Implementation based on the book:

> **Plasma Simulations by Example** by Lubos Brieda  
> Chapter 5, Section 5.6.4 - Scatter and Gather